### PR TITLE
Enable toadserver to run as a service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Pull base image.
+FROM quay.io/eris/base
+MAINTAINER Eris Industries <support@erisindustries.com>
+
+# configure install
+ENV NAME         toadserver
+ENV REPO 	eris-ltd/toadserver
+ENV ALIAS 	$REPO
+ENV BRANCH       master
+ENV BINARY_PATH  ./cmd/$NAME
+ENV CLONE_PATH   $GOPATH/src/github.com/$ALIAS
+ENV INSTALL_PATH $INSTALL_BASE/$NAME
+ENV INSTALL_BASE /usr/local/bin
+
+# install
+WORKDIR $CLONE_PATH
+RUN git clone -q https://github.com/$REPO $CLONE_PATH && go get github.com/eris-ltd/eris-cli/cmd/eris && go build && go install  # update201510112326
+
+# start script
+COPY start.sh $INSTALL_BASE/start
+
+# set user
+USER $USER
+WORKDIR $ERIS
+
+# boot
+VOLUME $ERIS
+EXPOSE 11113
+CMD ["start"]
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ TODO
 -> adding validators -> existing validator sends coins to new user, who can now POST/GET with whatever perms they are given.
 -> describe read/write-ability
 
+##Setup as a service
+Some work has been done to prepare toadserver to run as a service. Assuming that the toadserver docker image is available on quay.io, the following steps should work to run the server as a service:
+- 1) Run `eris files put toadserver.toml` and make a note of the file hash
+- 2) Run `eris services import toadserver <filehash>` where filehash is from step 1
+- 3) Run `eris services start toadserver`
+ 
+ There are a couple known issues with the service approach:
+ - 1) Environment variables MINTX_PUBKEY and MINTX_NODE_ADDR need to be set for toadserver to work correctly. Currently the only way to do this is to modify the start script and export the variables. Since these variables are different based on each installation, they are not set in the start.sh file in the code repo.
+ - 2) The service does not stop correctly when using `eris service stop toadserver`. After running the eris service stop command, run `docker ps`, find the container ID for toadserver, and run `docker stop <toadserver container>`.
+
 ##Other use cases
 - simple, scalable content hosting
 - science publishing

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ type Infos struct {
 }
 
 func main() {
+	fmt.Printf("toadserver service starting...\n")
 	mux := http.NewServeMux()
 	mux.HandleFunc("/postfile/", postHandler) //post a file with its contents to gateway, returns hash
 	//ts makes & signs a nameTx, then posts to a node, which does the broadcasting
@@ -23,6 +24,7 @@ func main() {
 	mux.HandleFunc("/getfile/", getHandler) // request by name, receive contents
 
 	http.ListenAndServe(":11113", mux)
+	fmt.Printf("blockchain notary service listening on port 11113...\n")
 }
 
 //-------------------------------------------------------

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+blockchain-digital-notary


### PR DESCRIPTION
Add a Dockerfile and start.sh script to enable the toadserver to
be built as a docker image suitable for use as an Eris service.
The Dockerfile and toadserver.toml file make some assumptions
about where the docker image is hosted and the github path.

Known issues:
- Environment variables must be provided for toadserver to
work correctly; these vary by environment and must be set
in the start script.

- Service does not stop from `eris stop toadserver`.